### PR TITLE
Fix ValueError with invalid field name in format.

### DIFF
--- a/hidden_code_block.py
+++ b/hidden_code_block.py
@@ -101,7 +101,7 @@ def visit_hcb_html(self, node):
     # block that was just made.
     code_block = self.body[-1]
 
-    fill_header = {'divname': 'hiddencodeblock{}'.format(HCB_COUNTER), 
+    fill_header = {'divname': 'hiddencodeblock{0}'.format(HCB_COUNTER), 
                    'startdisplay': 'none' if node['starthidden'] else 'block', 
                    'label': node.get('label'), 
                    }


### PR DESCRIPTION
```
  File "/Users/skumaran/github/experiments/sphinxextension/exampleproject/hidden_code_block.py", line 104, in visit_hcb_html
    fill_header = {'divname': 'hiddencodeblock{}'.format(HCB_COUNTER),
ValueError: zero length field name in format
```
