### PR TITLE
fix compat with Sphinx 1.7

### DIFF
--- a/hidden_code_block.py
+++ b/hidden_code_block.py
@@ -35,7 +35,6 @@ Released under the WTFPL (http://sam.zoy.org/wtfpl/).
 from docutils import nodes
 from docutils.parsers.rst import directives
 from sphinx.directives.code import CodeBlock
-from sphinx.util.compat import make_admonition
 
 HCB_COUNTER = 0
 


### PR DESCRIPTION
This extension is broken by the recent Sphinx in a way very similar to
https://github.com/spinus/sphinxcontrib-images/issues/41

The way to load admonitions changed in between. The good news is that
this extension does not use admonitions, so this patch simply removes
the extraneous import line.